### PR TITLE
cifsd-test-result: enable smb2 leases in smb.conf

### DIFF
--- a/testsuites/smb.conf
+++ b/testsuites/smb.conf
@@ -2,6 +2,7 @@
         workgroup = DRIVER
         netbios name = CIFSSRV
 	share:fake_fscaps = 0
+	smb2 leases = yes
 
 [cifsd-test1]
         comment = content server share1


### PR DESCRIPTION
Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>